### PR TITLE
fix(README): Fixed encoding error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ json rpc 2.0 protocol implementation for asyncio, without transport.
 
 specification: http://www.jsonrpc.org/
 
-## Usage:
+## Usage:
 Example to resolve request:
 
 


### PR DESCRIPTION
The character between ## and Usage is a `0xc2` which crashes when pip tried to decode it in `ascii` (default when no encoding env vars)